### PR TITLE
Crash fix & .NET update

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -15,7 +15,7 @@
     <Copyright>Demerzel Solutions Limited</Copyright>
     <SourceRevisionId Condition="'$(Commit)' != ''">$(Commit.Substring(0, 8))</SourceRevisionId>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
+    <VersionSuffix>preview.2</VersionSuffix>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Nethermind.Crypto.SecP256r1/Secp256r1.cs
+++ b/src/Nethermind.Crypto.SecP256r1/Secp256r1.cs
@@ -14,10 +14,10 @@ public static partial class Secp256r1
 
     static Secp256r1() => SetLibraryFallbackResolver();
 
-    private struct GoSlice(nint data, long len)
+    private readonly struct GoSlice(nint data, long len)
     {
-        public nint Data = data;
-        public long Len = len, Cap = len;
+        public readonly nint Data = data;
+        public readonly long Len = len, Cap = len;
     }
 
     [LibraryImport(LibraryName, SetLastError = true)]


### PR DESCRIPTION
- Updated to .NET 9
- Marked marshalled Go struct as read-only
- Bumped preview version